### PR TITLE
Move function body out of argument list

### DIFF
--- a/sequential/example.md
+++ b/sequential/example.md
@@ -16,9 +16,9 @@ Now for a larger example to consolidate what we have learnt so far. Assume we ha
     (format-temps rest)))
 
 (defun f->c
-  (((tuple name (tuple 'C temp))
+  (((tuple name (tuple 'C temp)))
     ;; No conversion needed
-    (tuple name (tuple 'C temp))))
+    (tuple name (tuple 'C temp)))
   (((tuple name (tuple 'F temp)))
     ;; Do the conversion
     (tuple name (tuple 'C (/ (* (- temp 32) 5) 9)))))


### PR DESCRIPTION
The first body of `f->c` was within the parentheses for the argument
list in the temperature example.
